### PR TITLE
Add test tooling and run tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,25 @@
+name: "CI"
+on:
+  push:
+  pull_request:
+
+
+jobs:
+  checks:
+    name: checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install Python 3.14
+        run: uv python install 3.14
+
+      - name: Run linter checks
+        run: make check-lint
+
+      - name: Run format checks
+        run: make check-fmt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,9 @@
 name: "CI"
 on:
   push:
+    branches:
+      - develop
+      - hotfix/*
   pull_request:
 
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,8 +9,8 @@ on:
       - main
       - develop
 jobs:
-  checks:
-    name: checks
+  ci:
+    name: ci
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,3 +27,4 @@ jobs:
 
       - name: Run format checks
         run: make check-fmt
+    

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,4 +27,7 @@ jobs:
 
       - name: Run format checks
         run: make check-fmt
+      
+      - name: Run test
+        run: make test
     

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,8 +5,9 @@ on:
       - develop
       - hotfix/*
   pull_request:
-
-
+    branches:
+      - main
+      - develop
 jobs:
   checks:
     name: checks

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,111 @@
+Contributing to the LandSight backend
+=====================================
+
+Welcome! This document explains how to set up your environment and which conventions to follow before submitting changes.
+
+Quick start
+-----------
+
+1. Clone the repository and ``cd backend``.
+2. Set up dev dependencies and hooks::
+
+       make setup-dev
+
+3. Make sure `uv <https://docs.astral.sh/uv/>`_ is installed.
+
+Workflow
+--------
+
+- Branches: start from ``main`` and choose a descriptive prefix:
+
+  - ``feature/<summary>`` — new functionality or API surface.
+  - ``bugfix/<summary>`` — fixes for existing defects.
+  - ``refactor/<summary>`` — architectural changes without behavioral changes.
+  - ``chore/<summary>`` — infrastructure, configs, dependency/tooling updates.
+  - ``docs/<summary>`` — documentation, guides, diagrams, examples.
+  - ``test/<summary>`` — work on tests and fixtures.
+  - ``ci/<summary>`` — CI/CD pipelines and automation.
+  - ``hotfix/<summary>`` — urgent fixes destined for the stable branch.
+  - ``release/<version>`` — preparing a release (changelog, version bump).
+
+- Commits: follow `Conventional Commits <https://www.conventionalcommits.org/en/v1.0.0/>`_. Main types:
+
+  - ``feat:`` — add new functionality or API.
+  - ``fix:`` — fix bugs or regressions.
+  - ``refactor:`` — restructure code without changing external behavior.
+  - ``chore:`` — infrastructure, configuration, dependency/tooling maintenance.
+  - ``docs:`` — documentation and examples.
+  - ``test:`` — tests and fixtures.
+  - ``ci:`` — CI/CD pipelines.
+  - ``build:`` — build system, packaging, Docker.
+  - ``perf:`` — performance optimizations.
+  - ``hotfix:`` — urgent production fixes.
+  - ``revert:`` — revert previous commits.
+  - Use scopes (``type(scope): …``) to narrow the affected area.
+  - Add ``!`` before the colon (``type(scope)!: …``) to mark breaking changes.
+
+- Branch flow:
+
+  - ``main`` — stable branch; only release-ready code lands here.
+  - ``develop`` — integration branch. Merge all working branches via PRs here and run checks/QA.
+  - ``feature/*``, ``bugfix/*``, ``refactor/*``, ``chore/*``, ``docs/*``, ``test/*``, ``ci/*`` — working branches. Create them from the latest ``main`` and rebase frequently onto ``develop``/``main``.
+  - ``hotfix/*`` — emergency fixes. Merge into ``main`` (with prior agreement) and then back into ``develop``.
+  - When ``develop`` is ready for release, merge into ``main`` and bump the version.
+
+Quality checks
+--------------
+
+- **Lint/typing/format** — ``make check`` (runs ``ty`` and ``ruff``).
+- **Tests** — ``make test`` (``uv run --extra=test pytest``). Ensure the suite is green before opening a PR.
+- **Logging** — initialize logging via ``app.logging.configure_logging()`` and ``get_logger()`` in your entry points.
+- **Documentation** — write docstrings in reStructuredText (PEP 257). Ruff enforces ``lint.pydocstyle.convention = "pep257"``.
+
+Versioning
+----------
+
+- We follow SemVer: ``MAJOR.MINOR.PATCH``.
+
+  - ``MAJOR`` — breaking API/contract changes.
+  - ``MINOR`` — new functionality without breaking compatibility.
+  - ``PATCH`` — backward-compatible bug fixes.
+
+- The version lives in ``src/app/__meta__.py`` and is exposed via ``app.__version__``.
+
+Before opening a pull request
+-----------------------------
+
+1. Rebase or merge the latest ``main`` into your branch.
+2. Run::
+
+       pre-commit run --all-files
+       make check
+       make test
+
+3. Keep commits small and well described.
+4. Craft your pull request carefully:
+
+   - Title: ``<type>: <short summary>`` — e.g. ``feat: add logging helpers``.
+   - Description should include:
+
+     1. **What** changed (key bullet points).
+     2. **Why** it is needed (motivation, link to issue/task).
+     3. **How to verify** (manual steps or commands).
+     4. **Checklist** — confirm lint/tests/docs/migrations are handled.
+
+   - Attach screenshots/logs if API behavior or UI visibly changes.
+   - Mention dependencies on other PRs/branches, if any.
+
+Issues and questions
+--------------------
+
+- Check for duplicates and discuss the idea in chat if you are unsure before creating a new issue.
+- Title: briefly describe the problem/feature (``bug:``, ``feature:``, ``doc:``, etc.).
+- Minimum issue template:
+
+  1. **Context** — required outcome or failing scenario.
+  2. **Steps / Expected / Actual** — reproduction steps and expected vs actual result (for bugs).
+  3. **Additional info** — logs, screenshots, specs.
+  4. **Priority / Impact** — severity and blocking impact.
+- For features — attach designs, API sketches, or business requirements.
+- For bugs — propose a fix idea or note if a hotfix is needed.
+- Use the team chat for quick questions so the tracker stays focused.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -3,6 +3,14 @@ Contributing to the LandSight backend
 
 Welcome! This document explains how to set up your environment and which conventions to follow before submitting changes.
 
+Requirements
+------------
+
+- Python ≥ 3.14 (managed via uv) 
+- `uv <https://docs.astral.sh/uv/>`_ ≥ 0.9
+- `make <https://www.gnu.org/software/make/>`_ ≥ 4.4
+- `pre-commit <https://pre-commit.com/>`_ ≥ 4.4
+
 Quick start
 -----------
 
@@ -11,6 +19,9 @@ Quick start
 
        make setup-dev
 
+   Optional commands:
+   - ``make install`` — install prod dependencies only.
+   - ``make install-dev`` — install prod + dev extras without installing hooks.
 3. Make sure `uv <https://docs.astral.sh/uv/>`_ is installed.
 
 Workflow
@@ -58,6 +69,7 @@ Quality checks
 - **Lint/typing/format** — ``make check`` (runs ``ty`` and ``ruff``).
 - **Tests** — ``make test`` (``uv run --extra=test pytest``). Ensure the suite is green before opening a PR.
 - **Logging** — initialize logging via ``app.logging.configure_logging()`` and ``get_logger()`` in your entry points.
+- **Formatting** — ``make fmt``.
 - **Documentation** — write docstrings in reStructuredText (PEP 257). Ruff enforces ``lint.pydocstyle.convention = "pep257"``.
 
 Versioning

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ install-dev: install
 setup-dev: install-dev
 	$(PRE-COMMIT) install
 
+.PHONY: test
+test:
+	$(UV) run --extra=test pytest
+	
 .PHONY: check-fmt
 check-fmt:
 	$(UV) run --extra=fmt ruff format --preview --check

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Backend for land parcel analysis: geometry validation, legal constraints, natural and infrastructure profiles, suitability scoring, background workflows. Stores domain logic, DTO/contracts, migrations, API and worker entrypoints.
 
 ## Requirements
-- [uv](https://docs.astral.sh/uv/)
-- make
-- pre-commit
+- [uv](https://docs.astral.sh/uv/) ≥ 0.9
+- make ≥ 4.4
+- pre-commit ≥ 4.4
 
 ## Setup
 ```bash

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ make setup-dev       # install dev deps and setup dev environment
 make check      # check-lint + check-fmt
 ```
 
+## Run tests
+```bash
+make test       # run tests
+```
+
 ## Formatting
 ```bash
 make fmt        # auto formatting

--- a/README.md
+++ b/README.md
@@ -2,31 +2,7 @@
 
 Backend for land parcel analysis: geometry validation, legal constraints, natural and infrastructure profiles, suitability scoring, background workflows. Stores domain logic, DTO/contracts, migrations, API and worker entrypoints.
 
-## Requirements
-- [uv](https://docs.astral.sh/uv/) ≥ 0.9
-- [make](https://www.gnu.org/software/make/) ≥ 4.4
-- [pre-commit](https://pre-commit.com/) ≥ 4.4
-
-## Setup
-```bash
-make install         # install dependencies for prod
-
-make install-dev     # install dependencies for development
-
-make setup-dev       # install dev deps and setup dev environment
-```
-
-## Run checks
-```bash
-make check      # check-lint + check-fmt
-```
-
-## Run tests
-```bash
-make test       # run tests
-```
-
-## Formatting
-```bash
-make fmt        # auto formatting
-```
+=======
+## Development
+See [CONTRIBUTING.rst](CONTRIBUTING.rst) for requirements, setup commands, and development workflow.
+>>>>>>> 034db08 (docs: move setup requirements into contributing guide)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Backend for land parcel analysis: geometry validation, legal constraints, natura
 
 ## Requirements
 - [uv](https://docs.astral.sh/uv/) ≥ 0.9
-- make ≥ 4.4
-- pre-commit ≥ 4.4
+- [make](https://www.gnu.org/software/make/) ≥ 4.4
+- [pre-commit](https://pre-commit.com/) ≥ 4.4
 
 ## Setup
 ```bash

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 Backend for land parcel analysis: geometry validation, legal constraints, natural and infrastructure profiles, suitability scoring, background workflows. Stores domain logic, DTO/contracts, migrations, API and worker entrypoints.
 
 ## Requirements
-- Python 3.14+
 - [uv](https://docs.astral.sh/uv/)
 - make
 - pre-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ optional-dependencies.fmt = [
 optional-dependencies.lint = [
   "ty>=0.0.1a29",
 ]
+optional-dependencies.test = [
+    "pytest>=9.0.1",
+]
 
 [tool.hatch.version]
 source = "code"
@@ -91,3 +94,19 @@ lint.pydocstyle.convention = "pep257"
 [tool.ty.environment]
 root = [ "src", "tests" ]
 python-version = "3.14"
+
+[tool.pytest.ini_options]
+pythonpath = [ "src" ]
+testpaths = [ "tests" ]
+addopts = [
+  "-ra",
+  "--strict-config",
+  "--strict-markers",
+  "--disable-warnings",
+]
+xfail_strict = true
+log_cli = true
+log_cli_level = "INFO"
+filterwarnings = [
+  "error",
+]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,3 @@
+def test_smoke() -> None:
+    """Smoke test."""
+    assert True


### PR DESCRIPTION
- Added pytest to the test dependency group
- Basic configured of pytest in pyproject
- Added a test launch target to the Makefile
- Described the launch using the Makefile target in CONTRIBUTING.md
- Renamed job `checks` to `ci` in CI
- Added a test launch step to CI