### PR TITLE
Feature support test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,3 +27,6 @@ jobs:
 
       - name: Run format checks
         run: make check-fmt
+
+      - name: Run tests
+        run: make test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,8 +9,8 @@ on:
       - main
       - develop
 jobs:
-  checks:
-    name: checks
+  ci:
+    name: CI
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ install-dev: install
 setup-dev: install-dev
 	$(PRE-COMMIT) install
 
+.PHONY: test
+test:
+	$(UV) run --extra=test pytest
+
 .PHONY: check-fmt
 check-fmt:
 	$(UV) run --extra=fmt ruff format --preview --check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,8 @@ lint.per-file-ignores."**/__init__.py" = [
   "F401", # allow unused re-exports
 ]
 lint.per-file-ignores."tests/**.py" = [
-  "S101", # allow assert statements in tests (Bandit S101)
+  "PLR2004", # magic value comparison
+  "S101",    # allow assert statements in tests (Bandit S101)
 ]
 lint.isort.combine-as-imports = true
 lint.isort.force-single-line = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ optional-dependencies.fmt = [
 optional-dependencies.lint = [
   "ty>=0.0.1a29",
 ]
+optional-dependencies.test = [
+  "pytest>=9.0.1",
+]
 
 [tool.hatch.version]
 source = "code"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,22 @@ lint.isort.known-first-party = [ "app" ]
 lint.isort.lines-after-imports = 2
 lint.pydocstyle.convention = "pep257"
 
+[tool.pytest.ini_options]
+pythonpath = [ "src" ]
+testpaths = [ "tests" ]
+addopts = [
+  "-ra",
+  "--strict-config",
+  "--strict-markers",
+  "--disable-warnings",
+]
+xfail_strict = true
+log_cli = true
+log_cli_level = "INFO"
+filterwarnings = [
+  "error",
+]
+
 [tool.ty.environment]
 root = [ "src", "tests" ]
 python-version = "3.14"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,13 @@
+import re
+
+from app import __version__
+
+
+VERSION_PATTERN = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<suffix>.*)$")
+
+
+def test_version_format() -> None:
+    """Ensure __version__ looks like major.minor.patch optionally followed by any suffix such as 'a0'."""
+    match = VERSION_PATTERN.match(__version__)
+    assert match is not None, "Version must start with three numeric release components."
+    assert all(part.isdigit() for part in match.group("major", "minor", "patch"))


### PR DESCRIPTION
- Added `pytest` dependency to the `test` group
- Basic `pytest` configuration set up.
- Ignored rule [PLR2004](https://docs.astral.sh/ruff/rules/magic-value-comparison/) for tests.
- Added `test` target to the Makefile .
- Renamed job from `checks` to `ci`.
- Added a step to run tests in the `ci` job. 
