### PR TITLE
Add base config and env example

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,9 @@ authors = [
 requires-python = ">=3.14"
 classifiers = [ "Programming Language :: Python :: 3 :: Only", "Programming Language :: Python :: 3.14" ]
 dynamic = [ "version" ]
-dependencies = [  ]
+dependencies = [
+  "pydantic-settings>=2.12",
+]
 
 optional-dependencies.fmt = [
   "ruff>=0.14.7",

--- a/src/app/platform/__init__.py
+++ b/src/app/platform/__init__.py
@@ -1,0 +1,4 @@
+from . import constants
+
+
+__all__ = ("constants",)

--- a/src/app/platform/__init__.py
+++ b/src/app/platform/__init__.py
@@ -1,4 +1,7 @@
-from . import constants
+from . import config, constants
 
 
-__all__ = ("constants",)
+__all__ = (
+    "config",
+    "constants",
+)

--- a/src/app/platform/config/__init__.py
+++ b/src/app/platform/config/__init__.py
@@ -1,0 +1,4 @@
+from .models import BaseConfig
+
+
+__all__ = ("BaseConfig",)

--- a/src/app/platform/config/models.py
+++ b/src/app/platform/config/models.py
@@ -1,0 +1,20 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from app.platform.constants import ENV_FILE
+
+
+class BaseConfig(BaseSettings):
+    """Base settings for the application.
+
+    Notes
+    -----
+    Configuration is loaded from environment variables and the project-level `.env`
+    file specified by `ENV_FILE`. Unknown variables are ignored. Nested settings
+    can be provided using the `__` delimiter.
+    """
+
+    model_config = SettingsConfigDict(
+        extra="ignore",
+        env_nested_delimiter="__",
+        env_file=ENV_FILE,
+    )

--- a/src/app/platform/constants.py
+++ b/src/app/platform/constants.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+
+
+PROJECT_DIR = Path(__file__).parent.parent.parent.parent.resolve()
+ENV_FILE = PROJECT_DIR / ".env"


### PR DESCRIPTION
## Summary
- add `pydantic-settings` dependency
- add base config model
- introduce shared constants for project directory and env file location
- provide `.env.example` placeholder for environment configuration
