### PR TITLE
Unify install target in Makefile

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -28,7 +28,7 @@ Setup steps:
 
    .. code-block:: bash
 
-      make setup-dev
+      make install
 
 
 .. _code-quality:

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,8 @@ DOCS_BUILD_DIR = $(DOCS_DIR)/_build
 
 .PHONY: install
 install:
-	$(UV) sync
-
-.PHONY: install-dev
-install-dev: install
-	$(UV) sync --all-extras
-
-.PHONY: setup-dev
-setup-dev: install-dev
+	$(UV) venv
+	$(UV) sync --all-extras --all-groups
 	$(PRE-COMMIT) install
 
 .PHONY: test


### PR DESCRIPTION
## Summary
- Combine install-dev and setup-dev into install target
- The install target now initializes the venv
- Update the contribution docs