### PR TITLE
Switch to dependency groups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,28 +7,28 @@ DOCS_BUILD_DIR = $(DOCS_DIR)/_build
 .PHONY: install
 install:
 	$(UV) venv
-	$(UV) sync --all-extras --all-groups
+	$(UV) sync --all-groups
 	$(PRE-COMMIT) install
 
 .PHONY: test
 test:
-	$(UV) run --extra=test pytest
+	$(UV) run --group=test pytest
 
 .PHONY: check-fmt
 check-fmt:
-	$(UV) run --extra=fmt ruff format --preview --check
+	$(UV) run --group=lint ruff format --preview --check
 
 .PHONY: check-lint
 check-lint:
-	$(UV) run --extra=lint ty check
-	$(UV) run --extra=fmt ruff check --show-fixes --preview
+	$(UV) run --group=lint ty check
+	$(UV) run --group=lint ruff check --show-fixes --preview
 
 .PHONY: check
 check: check-lint check-fmt
 
 .PHONY: fmt
 fmt:
-	$(UV) run --extra=fmt ruff format --preview
+	$(UV) run --group=lint ruff format --preview
 
 .PHONY: docs-clean
 docs-clean:
@@ -36,8 +36,8 @@ docs-clean:
 
 .PHONY: docs-build
 docs-build: docs-clean
-	$(UV) run --extra=docs sphinx-build -b html $(DOCS_DIR) $(DOCS_BUILD_DIR)
+	$(UV) run --group=docs sphinx-build -b html $(DOCS_DIR) $(DOCS_BUILD_DIR)
 
 .PHONY: docs-serve
 docs-serve:
-	$(UV) run --extra=docs sphinx-autobuild $(DOCS_DIR) $(DOCS_BUILD_DIR)
+	$(UV) run --group=dev sphinx-autobuild $(DOCS_DIR) $(DOCS_BUILD_DIR)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,20 +17,6 @@ dynamic = [ "version" ]
 dependencies = [
   "pydantic-settings>=2.12",
 ]
-optional-dependencies.docs = [
-  "furo>=2025.9.25",
-  "sphinx>=8.2.3",
-  "sphinx-autobuild>=2025.8.25",
-]
-optional-dependencies.fmt = [
-  "ruff>=0.14.7",
-]
-optional-dependencies.lint = [
-  "ty>=0.0.1a29",
-]
-optional-dependencies.test = [
-  "pytest>=9.0.1",
-]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dynamic = [ "version" ]
 dependencies = [
   "pydantic-settings>=2.12",
 ]
-
 optional-dependencies.docs = [
   "furo>=2025.9.25",
   "sphinx>=8.2.3",
@@ -31,6 +30,23 @@ optional-dependencies.lint = [
 ]
 optional-dependencies.test = [
   "pytest>=9.0.1",
+]
+
+[dependency-groups]
+dev = [
+  "land-sight-backend[docs,lint,test]",
+  "sphinx-autobuild",
+]
+test = [
+  "pytest>=9.0.1",
+]
+docs = [
+  "furo>=2025.9.25",
+  "sphinx>=8.2.3",
+]
+lint = [
+  "ruff>=0.14.7",
+  "ty>=0.0.1a29",
 ]
 
 [tool.hatch.version]


### PR DESCRIPTION
- add dependency grops: `test`. `docs`, `dev`, `lint`
- use dependency groups in the Makefile instead of optional dependencies
- drop optional dependencies: `lint`, `fmt`,`docs`, `test`