### PR TITLE
Unify lint targets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,11 +22,8 @@ jobs:
       - name: Install Python 3.14
         run: uv python install 3.14
 
-      - name: Run linter checks
-        run: make check-lint
-
-      - name: Run format checks
-        run: make check-fmt
+      - name: Run lint checks
+        run: make lint
 
       - name: Run tests
         run: make test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,13 +16,6 @@ repos:
     hooks:
       - id: lint
         name: lint
-        entry: make check-lint
+        entry: make lint
         language: system
         pass_filenames: true
-        types: [python]
-      - id: fmt
-        name: fmt
-        entry: make check-fmt
-        language: system
-        pass_filenames: true
-        types: [python]

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -46,9 +46,7 @@ Auxiliary Commands
 
 .. code-block:: bash
 
-   make check-lint  # Run static analysis.
-   make check-fmt   # Check code style and formatting.
-   make checks      # Run all checks.
+   make lint        # Run static analysis.
    make fmt         # Format the code.
 
 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,12 @@ check-lint:
 .PHONY: check
 check: check-lint check-fmt
 
+.PHONY: lint
+lint:
+	$(UV) run --group=lint ty check
+	$(UV) run --group=lint ruff format --preview --check
+	$(UV) run --group=lint ruff check --show-fixes --preview
+
 .PHONY: fmt
 fmt:
 	$(UV) run --group=lint ruff format --preview

--- a/Makefile
+++ b/Makefile
@@ -14,18 +14,6 @@ install:
 test:
 	$(UV) run --group=test pytest
 
-.PHONY: check-fmt
-check-fmt:
-	$(UV) run --group=lint ruff format --preview --check
-
-.PHONY: check-lint
-check-lint:
-	$(UV) run --group=lint ty check
-	$(UV) run --group=lint ruff check --show-fixes --preview
-
-.PHONY: check
-check: check-lint check-fmt
-
 .PHONY: lint
 lint:
 	$(UV) run --group=lint ty check


### PR DESCRIPTION
- add `lint` target
- use `lint` target for quality checks into ci and pre-commit
- update contributig docs
- drop legacy targets