### PR TITLE
chore: add support coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ install:
 
 .PHONY: test
 test:
-	$(UV) run --group=test pytest
+	$(UV) run --group=test pytest --cov=src/app --cov-report=term-missing --cov-append
 
 .PHONY: lint
 lint:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dev = [
 ]
 test = [
   "pytest>=9.0.1",
+  "pytest-cov>=7",
 ]
 docs = [
   "furo>=2025.9.25",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,15 @@ filterwarnings = [
   "error",
 ]
 
+[tool.coverage.run]
+source = [ "src/app" ]
+branch = true
+
+[tool.coverage.report]
+exclude_lines = [
+  "pragma: not covered",
+]
+
 [tool.ty.environment]
 root = [ "src", "tests" ]
 python-version = "3.14"


### PR DESCRIPTION
## Summary
Add test coverage support.

## Changes
- add pytest-cov to the test dependency group
- basic configure coverage
- add coverage options when running tests via `make test`