### PR TITLE
chore: towncrier setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+<!-- towncrier release notes start -->

--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,11 @@ docs-build: docs-clean
 .PHONY: docs-serve
 docs-serve:
 	$(UV) run --group=dev sphinx-autobuild $(DOCS_DIR) $(DOCS_BUILD_DIR)
+
+.PHONY: changelog-build
+changelog-build:
+	$(UV) run --group=docs towncrier build
+
+.PHONY: changelog-fragment
+changelog-fragment:
+	$(UV) run --group=docs towncrier create

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,41 @@ filename = "CHANGELOG.md"
 title_format = "## [{version}](https://github.com/LandSight/backend/releases/tag/{version}) - {project_date}"
 issue_format = "[#{issue}](https://github.com/LandSight/backend/issues/{issue})"
 
+[[tool.towncrier.type]]
+name = "Feature"
+directory = "feature"
+showcontent = true
+
+[[tool.towncrier.type]]
+name = "Bugfix"
+directory = "bugfix"
+showcontent = true
+
+[[tool.towncrier.type]]
+name = "Security"
+directory = "security"
+showcontent = true
+
+[[tool.towncrier.type]]
+name = "Deprecation"
+directory = "deprecation"
+showcontent = true
+
+[[tool.towncrier.type]]
+name = "Removal"
+directory = "removal"
+showcontent = true
+
+[[tool.towncrier.type]]
+name = "Docs"
+directory = "docs"
+showcontent = true
+
+[[tool.towncrier.type]]
+name = "Ops"
+directory = "ops"
+showcontent = true
+
 [tool.ty.environment]
 root = [ "src", "tests" ]
 python-version = "3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ test = [
 docs = [
   "furo>=2025.9.25",
   "sphinx>=8.2.3",
+  "towncrier>=25.8",
 ]
 lint = [
   "ruff>=0.14.7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,12 @@ exclude_lines = [
   "pragma: not covered",
 ]
 
+[tool.towncrier]
+directory = "changelog.d"
+filename = "CHANGELOG.md"
+title_format = "## [{version}](https://github.com/LandSight/backend/releases/tag/{version}) - {project_date}"
+issue_format = "[#{issue}](https://github.com/LandSight/backend/issues/{issue})"
+
 [tool.ty.environment]
 root = [ "src", "tests" ]
 python-version = "3.14"


### PR DESCRIPTION
## Summary
Introduce Towncrier to manage the project CHANGELOG and add Makefile helpers for building the changelog and creating news fragments.

## Context 
Maintaining the CHANGELOG manually is error-prone and time-consuming. Towncrier standardizes release notes via news fragments and generates a consistent changelog during release.

## Changes
- Added `towncrier` to the `docs` dependency group.
- Added Makefile targets:
  - `changelog-build`
  - `changelog-fragmet`
  
  