### PR TITLE
[Docs] Add versioning policy

### DIFF
--- a/docs/standarts/versioning.md
+++ b/docs/standarts/versioning.md
@@ -1,0 +1,18 @@
+# Versioning
+
+This project follows Semantic Versioning [SemVer](https://semver.org/) and uses a single version for the application.
+
+## SemVer Rules
+
+- **MAJOR**: [breaking changes](breaking-change.md) or backward-incompatible behavior
+- **MINOR**: backward-compatible features or API additions
+- **PATCH**: backward-compatible bug fixes and internal changes
+
+## Pre-release Tags
+
+We use release candidates for stabilization:
+
+- Format: `X.Y.Z-rc.N`
+- Examples: `1.2.0-rc.1`, `1.2.0-rc.2`
+- A release candidate must be followed by the final `X.Y.Z` without
+  additional changes that would invalidate the candidate

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -24,6 +24,7 @@ nav:
     - Issues: "standarts/issues.md"
     - Pull Requests: "standarts/pull-request.md"
     - Testing: "standarts/testing.md"
+    - Versioning: "standarts/versioning.md"
   - Contributing: "contributing.md"
   - Changelog: "changelog.md"
 plugins:


### PR DESCRIPTION
## Summary
Add versioning policy documentation and link it in the MkDocs navigation.

## Type
- [ ] Release
- [ ] Feature
- [ ] Fix
- [ ] Security
- [x] Docs
- [ ] Ops
- [ ] Internal
- [ ] Breaking change

## Changes
- add versioning policy page
- add versioning page to MkDocs navigation

## Verification
- [ ] `just check`

## Docs
- [x] Docs updated (if needed)

## Tests
- [ ] Tests added/updated (if needed)

## Changelog
- [ ] Added changelog fragment in `changelog.d/`
