### PR TITLE
chore(just): use env instead of deprecated env_var_or_default

### DIFF
--- a/justfile
+++ b/justfile
@@ -4,8 +4,8 @@ set dotenv-load := true
 VENV_DIR := ".venv"
 BUILD_DIR := "build"
 CACHE_DIR := ".cache"
-DOCS_HOST := env_var_or_default("DOCS_HOST", "127.0.0.1")
-DOCS_PORT := env_var_or_default("DOCS_PORT", "8008")
+DOCS_HOST := env("DOCS_HOST", "127.0.0.1")
+DOCS_PORT := env("DOCS_PORT", "8008")
 
 default:
     @just --list


### PR DESCRIPTION
## Summary
Using `env` instead of `env_var_or_default`.

## Type
- [ ] Release
- [ ] Feature
- [ ] Fix
- [ ] Security
- [ ] Docs
- [x] Ops
- [ ] Internal
- [ ] Breaking change

## Changes
<!-- Write down exactly what you changed. -->
- Replace deprecated `env_var_or_default` to `env`.

## Verification
- [x] `just check`

## Docs
- [ ] Docs updated (if needed)

## Tests
- [ ] Tests added/updated (if needed)

## Changelog
- [ ] Added changelog fragment in `changelog.d/`
